### PR TITLE
strict version of reown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.0.0",
             "dependencies": {
                 "@openzeppelin/merkle-tree": "^1.0.5",
-                "@reown/appkit": "^1.6.5",
-                "@reown/appkit-adapter-wagmi": "^1.6.5",
+                "@reown/appkit": "1.6.4",
+                "@reown/appkit-adapter-wagmi": "1.6.4",
                 "@vueuse/sound": "^2.0.1",
                 "@wagmi/connectors": "^5.7.5",
                 "@wagmi/core": "^2.16.3",
@@ -1554,43 +1554,43 @@
             }
         },
         "node_modules/@reown/appkit": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.6.5.tgz",
-            "integrity": "sha512-x72Tese2oB7BmJ2BiZIwBUYQ9/GESlANbL6PAAayOYFEyecmk3HVoUJVyNYzRmwfCYFHJvSmBkSkuAfya58SrQ==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.6.4.tgz",
+            "integrity": "sha512-7mP37wB+Bvth8ae9wCqxrXb1vLbUw5ZYVYieTgPoEjPk5Fk0twnNy9pkxl8OdpDmKFir1FbRQJEq5imLLQIa/Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-scaffold-ui": "1.6.5",
-                "@reown/appkit-siwe": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/universal-provider": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-scaffold-ui": "1.6.4",
+                "@reown/appkit-siwe": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/universal-provider": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "bs58": "6.0.0",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             }
         },
         "node_modules/@reown/appkit-adapter-wagmi": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.6.5.tgz",
-            "integrity": "sha512-TEat9qVh69ILbLnZmw1zRdYqabOLthcrlTMP2LJBhNybTljOcQzL/Rm7Bcz00WbmkiEA/o+kc+rzE5SSNzEtCQ==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.6.4.tgz",
+            "integrity": "sha512-gT65bf8HFHF1a9/St8kNHmYYMJm9H6ZXWwP6AnKl0WrZY1Sj6q7sumNcEvRpNFDlJu9ySPHFmCzkt6E7XxljiA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit": "1.6.5",
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-scaffold-ui": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/universal-provider": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit": "1.6.4",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-scaffold-ui": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/universal-provider": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "valtio": "1.11.2"
             },
             "peerDependencies": {
@@ -1602,24 +1602,24 @@
             }
         },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/core": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-            "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+            "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/relay-api": "1.0.11",
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "events": "3.3.0",
                 "lodash.isequal": "4.5.0",
@@ -1629,39 +1629,27 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-            "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@walletconnect/jsonrpc-utils": "^1.0.6",
-                "@walletconnect/safe-json": "^1.0.2",
-                "events": "^3.3.0",
-                "ws": "^7.5.1"
-            }
-        },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/sign-client": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-            "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+            "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@walletconnect/core": "2.17.5",
+                "@walletconnect/core": "2.17.2",
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0"
             }
         },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/types": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-            "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+            "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -1673,9 +1661,9 @@
             }
         },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/universal-provider": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-            "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+            "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -1685,17 +1673,17 @@
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/sign-client": "2.17.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/sign-client": "2.17.2",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0",
                 "lodash": "4.17.21"
             }
         },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/@walletconnect/utils": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-            "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+            "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hash": "5.7.0",
@@ -1711,11 +1699,12 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
+                "@walletconnect/types": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
-                "elliptic": "6.6.1",
+                "elliptic": "6.6.0",
+                "query-string": "7.1.3",
                 "uint8arrays": "3.1.0"
             }
         },
@@ -1726,9 +1715,9 @@
             "license": "MIT"
         },
         "node_modules/@reown/appkit-adapter-wagmi/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -1740,31 +1729,10 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/@reown/appkit-adapter-wagmi/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@reown/appkit-common": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.6.5.tgz",
-            "integrity": "sha512-D/RvPta4O1zxnenRWnWr28JZyvWOUl6ly3WU+CsH7YClAEs064i9BBN5b9h0+tTQ4gmuJZTbF8DPmbdt/MFCKg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.6.4.tgz",
+            "integrity": "sha512-TN8mKZYiTl7VQ7csrxxgB9EBsmp1qGj5dqcAv2JPZqD3rMkJtMCipIuf/Lg8gUjOJ3B8OyeNFDe8g+dhLZgTag==",
             "license": "Apache-2.0",
             "dependencies": {
                 "bignumber.js": "9.1.2",
@@ -1773,37 +1741,37 @@
             }
         },
         "node_modules/@reown/appkit-core": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-core/-/appkit-core-1.6.5.tgz",
-            "integrity": "sha512-vHuwDqpr0Bj2l+PXE/Kdcv62bEfTuOb+kIGZI2ztwOTBminvxWwi6LlAz5q3pgoCRI72lO+t6gdufETNcadZEw==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-core/-/appkit-core-1.6.4.tgz",
+            "integrity": "sha512-hewOtE6P+s5rYEcjB5lzgiALTH50xbjROkliulyHLasBUvbP/L/M5RIsuOM3n/9/3bUu/Sc3wX+cFdh0/YbBaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/universal-provider": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/universal-provider": "2.17.2",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             }
         },
         "node_modules/@reown/appkit-core/node_modules/@walletconnect/core": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-            "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+            "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/relay-api": "1.0.11",
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "events": "3.3.0",
                 "lodash.isequal": "4.5.0",
@@ -1813,39 +1781,27 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@reown/appkit-core/node_modules/@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-            "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@walletconnect/jsonrpc-utils": "^1.0.6",
-                "@walletconnect/safe-json": "^1.0.2",
-                "events": "^3.3.0",
-                "ws": "^7.5.1"
-            }
-        },
         "node_modules/@reown/appkit-core/node_modules/@walletconnect/sign-client": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-            "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+            "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@walletconnect/core": "2.17.5",
+                "@walletconnect/core": "2.17.2",
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0"
             }
         },
         "node_modules/@reown/appkit-core/node_modules/@walletconnect/types": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-            "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+            "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -1857,9 +1813,9 @@
             }
         },
         "node_modules/@reown/appkit-core/node_modules/@walletconnect/universal-provider": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-            "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+            "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -1869,17 +1825,17 @@
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/sign-client": "2.17.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/sign-client": "2.17.2",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0",
                 "lodash": "4.17.21"
             }
         },
         "node_modules/@reown/appkit-core/node_modules/@walletconnect/utils": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-            "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+            "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hash": "5.7.0",
@@ -1895,11 +1851,12 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
+                "@walletconnect/types": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
-                "elliptic": "6.6.1",
+                "elliptic": "6.6.0",
+                "query-string": "7.1.3",
                 "uint8arrays": "3.1.0"
             }
         },
@@ -1910,9 +1867,9 @@
             "license": "MIT"
         },
         "node_modules/@reown/appkit-core/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -1924,47 +1881,26 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/@reown/appkit-core/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@reown/appkit-polyfills": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.6.5.tgz",
-            "integrity": "sha512-UsJOeiuRu8zcDo5WojwcOq/sOQLkI00RsJaQu8tWJAd0jt4vhr6TdUkG5hkvbognihRwz4x8EY3UhaJagK2F0w==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.6.4.tgz",
+            "integrity": "sha512-JF4ypel+k6S108xTDwQVzouFqHCHSmItX6OcGf/MU+1VhIEQO9xxZV5ee2IVPtmgdgireNREPXr+VOepMNKBsQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "buffer": "6.0.3"
             }
         },
         "node_modules/@reown/appkit-scaffold-ui": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.6.5.tgz",
-            "integrity": "sha512-2pTbq8M/Qs9G+QtJybdKKzcXcfJnlNRV/w2LPTaF3vPfOHECixsftSPY7a7xV3tcOI5IbjPoBfp2OIWoIqfigA==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.6.4.tgz",
+            "integrity": "sha512-uhsmDE8PoWT2d4HvFkcwm3IdYUU7RQCPEv3SUjYWQP94g+vPgZl6TT1iEmw455WOcg0oeYZ9COFKBsGSgVmPbw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
                 "lit": "3.1.0"
             }
         },
@@ -2009,17 +1945,17 @@
             }
         },
         "node_modules/@reown/appkit-siwe": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.6.5.tgz",
-            "integrity": "sha512-hM8srnRW+hBctQreULUdjBX4sGWBreJr8q+21I4mli9BpAc+ciyH/ElHK765e1FOkkwTDh1rum56XcDKk4iYgw==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.6.4.tgz",
+            "integrity": "sha512-++gmCXQBu3XI1lG1h8by6XfExcPMfdEovrlO2t7z8dUwQETc7FY6yDkvTO2piCDvqpMGR5MDYmlIv19xIpuAwQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/utils": "2.17.2",
                 "lit": "3.1.0",
                 "valtio": "1.11.2"
             }
@@ -2034,9 +1970,9 @@
             }
         },
         "node_modules/@reown/appkit-siwe/node_modules/@walletconnect/types": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-            "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+            "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -2048,9 +1984,9 @@
             }
         },
         "node_modules/@reown/appkit-siwe/node_modules/@walletconnect/utils": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-            "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+            "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hash": "5.7.0",
@@ -2066,11 +2002,12 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
+                "@walletconnect/types": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
-                "elliptic": "6.6.1",
+                "elliptic": "6.6.0",
+                "query-string": "7.1.3",
                 "uint8arrays": "3.1.0"
             }
         },
@@ -2081,9 +2018,9 @@
             "license": "MIT"
         },
         "node_modules/@reown/appkit-siwe/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -2127,9 +2064,9 @@
             }
         },
         "node_modules/@reown/appkit-ui": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.6.5.tgz",
-            "integrity": "sha512-C+3AbmqoTQPinYKS7a6LEX0RdXDtroNVXbsKzo1r6BxFWGzHRBvyWn9CezqxbDLRCMVu3sYnXsNZboXU1L6ycg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.6.4.tgz",
+            "integrity": "sha512-NprNidUe6SDrFJJ5MQHc5J3Y+e/SI43OKNmVg9Lgui7HLPsowxC3T6YSBTXh1HwsKHOHyMjiLyefoi0fLNaZ7A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "lit": "3.1.0",
@@ -2177,17 +2114,17 @@
             }
         },
         "node_modules/@reown/appkit-utils": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.6.5.tgz",
-            "integrity": "sha512-PhiEvogcDqlD/8l7ds9AAZuaPUu62b5PSshQ+RXygXbcZLyJ/rSIYifCHlEPQvkQXOOjV1ZJ4J1eM4TeCMvjrg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.6.4.tgz",
+            "integrity": "sha512-Dq3Z02Qvc404DqRVZ2ZTYH9ldTmwTUxP5V77H8XUwKaTNEn+NsigQ+PdjsMbdYuqzqFhEOw0VUQABgziBbcNAA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/universal-provider": "2.17.5",
+                "@walletconnect/universal-provider": "2.17.2",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             },
@@ -2196,24 +2133,24 @@
             }
         },
         "node_modules/@reown/appkit-utils/node_modules/@walletconnect/core": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-            "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+            "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/relay-api": "1.0.11",
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "events": "3.3.0",
                 "lodash.isequal": "4.5.0",
@@ -2223,39 +2160,27 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@reown/appkit-utils/node_modules/@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-            "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@walletconnect/jsonrpc-utils": "^1.0.6",
-                "@walletconnect/safe-json": "^1.0.2",
-                "events": "^3.3.0",
-                "ws": "^7.5.1"
-            }
-        },
         "node_modules/@reown/appkit-utils/node_modules/@walletconnect/sign-client": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-            "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+            "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@walletconnect/core": "2.17.5",
+                "@walletconnect/core": "2.17.2",
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0"
             }
         },
         "node_modules/@reown/appkit-utils/node_modules/@walletconnect/types": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-            "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+            "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -2267,9 +2192,9 @@
             }
         },
         "node_modules/@reown/appkit-utils/node_modules/@walletconnect/universal-provider": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-            "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+            "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -2279,17 +2204,17 @@
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/sign-client": "2.17.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/sign-client": "2.17.2",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0",
                 "lodash": "4.17.21"
             }
         },
         "node_modules/@reown/appkit-utils/node_modules/@walletconnect/utils": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-            "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+            "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hash": "5.7.0",
@@ -2305,11 +2230,12 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
+                "@walletconnect/types": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
-                "elliptic": "6.6.1",
+                "elliptic": "6.6.0",
+                "query-string": "7.1.3",
                 "uint8arrays": "3.1.0"
             }
         },
@@ -2320,9 +2246,9 @@
             "license": "MIT"
         },
         "node_modules/@reown/appkit-utils/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -2334,58 +2260,37 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/@reown/appkit-utils/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@reown/appkit-wallet": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.6.5.tgz",
-            "integrity": "sha512-3o0+W/JP4rFpPInp4ScNLvr0N++98ErJIjQYjws6fP2KftQAkjUCGeMvYbVXf7sxh3Xu/WkN94SppOZ/WsBWBg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.6.4.tgz",
+            "integrity": "sha512-GfS4+ESVEGubkLrPEOE/QOSufkzSU7FZRK+RG4mD4zMjx2dcXEMrSBOuNOOf5PdgCFdd3XLCPfPj6HhMyVcVWQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
                 "@walletconnect/logger": "2.1.2",
                 "zod": "3.22.4"
             }
         },
         "node_modules/@reown/appkit/node_modules/@walletconnect/core": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-            "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+            "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-provider": "1.0.14",
                 "@walletconnect/jsonrpc-types": "1.0.4",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
-                "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/relay-api": "1.0.11",
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "events": "3.3.0",
                 "lodash.isequal": "4.5.0",
@@ -2395,39 +2300,27 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@reown/appkit/node_modules/@walletconnect/jsonrpc-ws-connection": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-            "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-            "license": "MIT",
-            "dependencies": {
-                "@walletconnect/jsonrpc-utils": "^1.0.6",
-                "@walletconnect/safe-json": "^1.0.2",
-                "events": "^3.3.0",
-                "ws": "^7.5.1"
-            }
-        },
         "node_modules/@reown/appkit/node_modules/@walletconnect/sign-client": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-            "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+            "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@walletconnect/core": "2.17.5",
+                "@walletconnect/core": "2.17.2",
                 "@walletconnect/events": "1.0.1",
                 "@walletconnect/heartbeat": "1.2.2",
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/logger": "2.1.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0"
             }
         },
         "node_modules/@reown/appkit/node_modules/@walletconnect/types": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-            "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+            "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -2439,9 +2332,9 @@
             }
         },
         "node_modules/@reown/appkit/node_modules/@walletconnect/universal-provider": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-            "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+            "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@walletconnect/events": "1.0.1",
@@ -2451,17 +2344,17 @@
                 "@walletconnect/jsonrpc-utils": "1.0.8",
                 "@walletconnect/keyvaluestorage": "1.1.1",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/sign-client": "2.17.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@walletconnect/sign-client": "2.17.2",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "events": "3.3.0",
                 "lodash": "4.17.21"
             }
         },
         "node_modules/@reown/appkit/node_modules/@walletconnect/utils": {
-            "version": "2.17.5",
-            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-            "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+            "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@ethersproject/hash": "5.7.0",
@@ -2477,11 +2370,12 @@
                 "@walletconnect/relay-auth": "1.0.4",
                 "@walletconnect/safe-json": "1.0.2",
                 "@walletconnect/time": "1.0.2",
-                "@walletconnect/types": "2.17.5",
+                "@walletconnect/types": "2.17.2",
                 "@walletconnect/window-getters": "1.0.1",
                 "@walletconnect/window-metadata": "1.0.1",
                 "detect-browser": "5.3.0",
-                "elliptic": "6.6.1",
+                "elliptic": "6.6.0",
+                "query-string": "7.1.3",
                 "uint8arrays": "3.1.0"
             }
         },
@@ -2492,9 +2386,9 @@
             "license": "MIT"
         },
         "node_modules/@reown/appkit/node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+            "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -2504,27 +2398,6 @@
                 "inherits": "^2.0.4",
                 "minimalistic-assert": "^1.0.1",
                 "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
-        "node_modules/@reown/appkit/node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@safe-global/safe-apps-provider": {
@@ -8613,81 +8486,70 @@
             "integrity": "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="
         },
         "@reown/appkit": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.6.5.tgz",
-            "integrity": "sha512-x72Tese2oB7BmJ2BiZIwBUYQ9/GESlANbL6PAAayOYFEyecmk3HVoUJVyNYzRmwfCYFHJvSmBkSkuAfya58SrQ==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.6.4.tgz",
+            "integrity": "sha512-7mP37wB+Bvth8ae9wCqxrXb1vLbUw5ZYVYieTgPoEjPk5Fk0twnNy9pkxl8OdpDmKFir1FbRQJEq5imLLQIa/Q==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-scaffold-ui": "1.6.5",
-                "@reown/appkit-siwe": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/types": "2.17.5",
-                "@walletconnect/universal-provider": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-scaffold-ui": "1.6.4",
+                "@reown/appkit-siwe": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/types": "2.17.2",
+                "@walletconnect/universal-provider": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "bs58": "6.0.0",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             },
             "dependencies": {
                 "@walletconnect/core": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-                    "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+                    "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
                     "requires": {
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-provider": "1.0.14",
                         "@walletconnect/jsonrpc-types": "1.0.4",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
-                        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/relay-api": "1.0.11",
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "events": "3.3.0",
                         "lodash.isequal": "4.5.0",
                         "uint8arrays": "3.1.0"
                     }
                 },
-                "@walletconnect/jsonrpc-ws-connection": {
-                    "version": "1.0.16",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-                    "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-                    "requires": {
-                        "@walletconnect/jsonrpc-utils": "^1.0.6",
-                        "@walletconnect/safe-json": "^1.0.2",
-                        "events": "^3.3.0",
-                        "ws": "^7.5.1"
-                    }
-                },
                 "@walletconnect/sign-client": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-                    "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+                    "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
                     "requires": {
-                        "@walletconnect/core": "2.17.5",
+                        "@walletconnect/core": "2.17.2",
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0"
                     }
                 },
                 "@walletconnect/types": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-                    "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+                    "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
@@ -8698,9 +8560,9 @@
                     }
                 },
                 "@walletconnect/universal-provider": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-                    "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+                    "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -8709,17 +8571,17 @@
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
-                        "@walletconnect/sign-client": "2.17.5",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/sign-client": "2.17.2",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0",
                         "lodash": "4.17.21"
                     }
                 },
                 "@walletconnect/utils": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-                    "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+                    "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
                     "requires": {
                         "@ethersproject/hash": "5.7.0",
                         "@ethersproject/transactions": "5.7.0",
@@ -8734,11 +8596,12 @@
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "@walletconnect/window-metadata": "1.0.1",
                         "detect-browser": "5.3.0",
-                        "elliptic": "6.6.1",
+                        "elliptic": "6.6.0",
+                        "query-string": "7.1.3",
                         "uint8arrays": "3.1.0"
                     }
                 },
@@ -8748,9 +8611,9 @@
                     "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
                 },
                 "elliptic": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-                    "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+                    "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "brorand": "^1.1.0",
@@ -8760,88 +8623,71 @@
                         "minimalistic-assert": "^1.0.1",
                         "minimalistic-crypto-utils": "^1.0.1"
                     }
-                },
-                "ws": {
-                    "version": "7.5.10",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-                    "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "requires": {}
                 }
             }
         },
         "@reown/appkit-adapter-wagmi": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.6.5.tgz",
-            "integrity": "sha512-TEat9qVh69ILbLnZmw1zRdYqabOLthcrlTMP2LJBhNybTljOcQzL/Rm7Bcz00WbmkiEA/o+kc+rzE5SSNzEtCQ==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.6.4.tgz",
+            "integrity": "sha512-gT65bf8HFHF1a9/St8kNHmYYMJm9H6ZXWwP6AnKl0WrZY1Sj6q7sumNcEvRpNFDlJu9ySPHFmCzkt6E7XxljiA==",
             "requires": {
-                "@reown/appkit": "1.6.5",
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-scaffold-ui": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/universal-provider": "2.17.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit": "1.6.4",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-scaffold-ui": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/universal-provider": "2.17.2",
+                "@walletconnect/utils": "2.17.2",
                 "valtio": "1.11.2"
             },
             "dependencies": {
                 "@walletconnect/core": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-                    "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+                    "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
                     "requires": {
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-provider": "1.0.14",
                         "@walletconnect/jsonrpc-types": "1.0.4",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
-                        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/relay-api": "1.0.11",
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "events": "3.3.0",
                         "lodash.isequal": "4.5.0",
                         "uint8arrays": "3.1.0"
                     }
                 },
-                "@walletconnect/jsonrpc-ws-connection": {
-                    "version": "1.0.16",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-                    "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-                    "requires": {
-                        "@walletconnect/jsonrpc-utils": "^1.0.6",
-                        "@walletconnect/safe-json": "^1.0.2",
-                        "events": "^3.3.0",
-                        "ws": "^7.5.1"
-                    }
-                },
                 "@walletconnect/sign-client": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-                    "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+                    "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
                     "requires": {
-                        "@walletconnect/core": "2.17.5",
+                        "@walletconnect/core": "2.17.2",
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0"
                     }
                 },
                 "@walletconnect/types": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-                    "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+                    "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
@@ -8852,9 +8698,9 @@
                     }
                 },
                 "@walletconnect/universal-provider": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-                    "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+                    "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -8863,17 +8709,17 @@
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
-                        "@walletconnect/sign-client": "2.17.5",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/sign-client": "2.17.2",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0",
                         "lodash": "4.17.21"
                     }
                 },
                 "@walletconnect/utils": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-                    "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+                    "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
                     "requires": {
                         "@ethersproject/hash": "5.7.0",
                         "@ethersproject/transactions": "5.7.0",
@@ -8888,11 +8734,12 @@
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "@walletconnect/window-metadata": "1.0.1",
                         "detect-browser": "5.3.0",
-                        "elliptic": "6.6.1",
+                        "elliptic": "6.6.0",
+                        "query-string": "7.1.3",
                         "uint8arrays": "3.1.0"
                     }
                 },
@@ -8902,9 +8749,9 @@
                     "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
                 },
                 "elliptic": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-                    "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+                    "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "brorand": "^1.1.0",
@@ -8914,19 +8761,13 @@
                         "minimalistic-assert": "^1.0.1",
                         "minimalistic-crypto-utils": "^1.0.1"
                     }
-                },
-                "ws": {
-                    "version": "7.5.10",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-                    "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "requires": {}
                 }
             }
         },
         "@reown/appkit-common": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.6.5.tgz",
-            "integrity": "sha512-D/RvPta4O1zxnenRWnWr28JZyvWOUl6ly3WU+CsH7YClAEs064i9BBN5b9h0+tTQ4gmuJZTbF8DPmbdt/MFCKg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.6.4.tgz",
+            "integrity": "sha512-TN8mKZYiTl7VQ7csrxxgB9EBsmp1qGj5dqcAv2JPZqD3rMkJtMCipIuf/Lg8gUjOJ3B8OyeNFDe8g+dhLZgTag==",
             "requires": {
                 "bignumber.js": "9.1.2",
                 "dayjs": "1.11.10",
@@ -8934,72 +8775,61 @@
             }
         },
         "@reown/appkit-core": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-core/-/appkit-core-1.6.5.tgz",
-            "integrity": "sha512-vHuwDqpr0Bj2l+PXE/Kdcv62bEfTuOb+kIGZI2ztwOTBminvxWwi6LlAz5q3pgoCRI72lO+t6gdufETNcadZEw==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-core/-/appkit-core-1.6.4.tgz",
+            "integrity": "sha512-hewOtE6P+s5rYEcjB5lzgiALTH50xbjROkliulyHLasBUvbP/L/M5RIsuOM3n/9/3bUu/Sc3wX+cFdh0/YbBaQ==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/universal-provider": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/universal-provider": "2.17.2",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             },
             "dependencies": {
                 "@walletconnect/core": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-                    "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+                    "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
                     "requires": {
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-provider": "1.0.14",
                         "@walletconnect/jsonrpc-types": "1.0.4",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
-                        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/relay-api": "1.0.11",
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "events": "3.3.0",
                         "lodash.isequal": "4.5.0",
                         "uint8arrays": "3.1.0"
                     }
                 },
-                "@walletconnect/jsonrpc-ws-connection": {
-                    "version": "1.0.16",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-                    "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-                    "requires": {
-                        "@walletconnect/jsonrpc-utils": "^1.0.6",
-                        "@walletconnect/safe-json": "^1.0.2",
-                        "events": "^3.3.0",
-                        "ws": "^7.5.1"
-                    }
-                },
                 "@walletconnect/sign-client": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-                    "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+                    "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
                     "requires": {
-                        "@walletconnect/core": "2.17.5",
+                        "@walletconnect/core": "2.17.2",
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0"
                     }
                 },
                 "@walletconnect/types": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-                    "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+                    "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
@@ -9010,9 +8840,9 @@
                     }
                 },
                 "@walletconnect/universal-provider": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-                    "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+                    "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -9021,17 +8851,17 @@
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
-                        "@walletconnect/sign-client": "2.17.5",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/sign-client": "2.17.2",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0",
                         "lodash": "4.17.21"
                     }
                 },
                 "@walletconnect/utils": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-                    "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+                    "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
                     "requires": {
                         "@ethersproject/hash": "5.7.0",
                         "@ethersproject/transactions": "5.7.0",
@@ -9046,11 +8876,12 @@
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "@walletconnect/window-metadata": "1.0.1",
                         "detect-browser": "5.3.0",
-                        "elliptic": "6.6.1",
+                        "elliptic": "6.6.0",
+                        "query-string": "7.1.3",
                         "uint8arrays": "3.1.0"
                     }
                 },
@@ -9060,9 +8891,9 @@
                     "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
                 },
                 "elliptic": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-                    "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+                    "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "brorand": "^1.1.0",
@@ -9072,33 +8903,27 @@
                         "minimalistic-assert": "^1.0.1",
                         "minimalistic-crypto-utils": "^1.0.1"
                     }
-                },
-                "ws": {
-                    "version": "7.5.10",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-                    "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "requires": {}
                 }
             }
         },
         "@reown/appkit-polyfills": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.6.5.tgz",
-            "integrity": "sha512-UsJOeiuRu8zcDo5WojwcOq/sOQLkI00RsJaQu8tWJAd0jt4vhr6TdUkG5hkvbognihRwz4x8EY3UhaJagK2F0w==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.6.4.tgz",
+            "integrity": "sha512-JF4ypel+k6S108xTDwQVzouFqHCHSmItX6OcGf/MU+1VhIEQO9xxZV5ee2IVPtmgdgireNREPXr+VOepMNKBsQ==",
             "requires": {
                 "buffer": "6.0.3"
             }
         },
         "@reown/appkit-scaffold-ui": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.6.5.tgz",
-            "integrity": "sha512-2pTbq8M/Qs9G+QtJybdKKzcXcfJnlNRV/w2LPTaF3vPfOHECixsftSPY7a7xV3tcOI5IbjPoBfp2OIWoIqfigA==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.6.4.tgz",
+            "integrity": "sha512-uhsmDE8PoWT2d4HvFkcwm3IdYUU7RQCPEv3SUjYWQP94g+vPgZl6TT1iEmw455WOcg0oeYZ9COFKBsGSgVmPbw==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
                 "lit": "3.1.0"
             },
             "dependencies": {
@@ -9141,16 +8966,16 @@
             }
         },
         "@reown/appkit-siwe": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.6.5.tgz",
-            "integrity": "sha512-hM8srnRW+hBctQreULUdjBX4sGWBreJr8q+21I4mli9BpAc+ciyH/ElHK765e1FOkkwTDh1rum56XcDKk4iYgw==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.6.4.tgz",
+            "integrity": "sha512-++gmCXQBu3XI1lG1h8by6XfExcPMfdEovrlO2t7z8dUwQETc7FY6yDkvTO2piCDvqpMGR5MDYmlIv19xIpuAwQ==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-ui": "1.6.5",
-                "@reown/appkit-utils": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
-                "@walletconnect/utils": "2.17.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-ui": "1.6.4",
+                "@reown/appkit-utils": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
+                "@walletconnect/utils": "2.17.2",
                 "lit": "3.1.0",
                 "valtio": "1.11.2"
             },
@@ -9164,9 +8989,9 @@
                     }
                 },
                 "@walletconnect/types": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-                    "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+                    "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
@@ -9177,9 +9002,9 @@
                     }
                 },
                 "@walletconnect/utils": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-                    "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+                    "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
                     "requires": {
                         "@ethersproject/hash": "5.7.0",
                         "@ethersproject/transactions": "5.7.0",
@@ -9194,11 +9019,12 @@
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "@walletconnect/window-metadata": "1.0.1",
                         "detect-browser": "5.3.0",
-                        "elliptic": "6.6.1",
+                        "elliptic": "6.6.0",
+                        "query-string": "7.1.3",
                         "uint8arrays": "3.1.0"
                     }
                 },
@@ -9208,9 +9034,9 @@
                     "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
                 },
                 "elliptic": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-                    "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+                    "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "brorand": "^1.1.0",
@@ -9252,9 +9078,9 @@
             }
         },
         "@reown/appkit-ui": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.6.5.tgz",
-            "integrity": "sha512-C+3AbmqoTQPinYKS7a6LEX0RdXDtroNVXbsKzo1r6BxFWGzHRBvyWn9CezqxbDLRCMVu3sYnXsNZboXU1L6ycg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.6.4.tgz",
+            "integrity": "sha512-NprNidUe6SDrFJJ5MQHc5J3Y+e/SI43OKNmVg9Lgui7HLPsowxC3T6YSBTXh1HwsKHOHyMjiLyefoi0fLNaZ7A==",
             "requires": {
                 "lit": "3.1.0",
                 "qrcode": "1.5.3"
@@ -9299,75 +9125,64 @@
             }
         },
         "@reown/appkit-utils": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.6.5.tgz",
-            "integrity": "sha512-PhiEvogcDqlD/8l7ds9AAZuaPUu62b5PSshQ+RXygXbcZLyJ/rSIYifCHlEPQvkQXOOjV1ZJ4J1eM4TeCMvjrg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.6.4.tgz",
+            "integrity": "sha512-Dq3Z02Qvc404DqRVZ2ZTYH9ldTmwTUxP5V77H8XUwKaTNEn+NsigQ+PdjsMbdYuqzqFhEOw0VUQABgziBbcNAA==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-core": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
-                "@reown/appkit-wallet": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-core": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
+                "@reown/appkit-wallet": "1.6.4",
                 "@walletconnect/logger": "2.1.2",
-                "@walletconnect/universal-provider": "2.17.5",
+                "@walletconnect/universal-provider": "2.17.2",
                 "valtio": "1.11.2",
                 "viem": "2.x"
             },
             "dependencies": {
                 "@walletconnect/core": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.5.tgz",
-                    "integrity": "sha512-m4rcW7QbO7pTV1C+UwOlTpUT9sjGxMs3DcFQ/QmayGPh1MYCC2S42ZTRswMWWqoHIhRjfxlNpO14UD3j0ya6sg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.2.tgz",
+                    "integrity": "sha512-O9VUsFg78CbvIaxfQuZMsHcJ4a2Z16DRz/O4S+uOAcGKhH/i/ln8hp864Tb+xRvifWSzaZ6CeAVxk657F+pscA==",
                     "requires": {
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-provider": "1.0.14",
                         "@walletconnect/jsonrpc-types": "1.0.4",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
-                        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+                        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/relay-api": "1.0.11",
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "events": "3.3.0",
                         "lodash.isequal": "4.5.0",
                         "uint8arrays": "3.1.0"
                     }
                 },
-                "@walletconnect/jsonrpc-ws-connection": {
-                    "version": "1.0.16",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-                    "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
-                    "requires": {
-                        "@walletconnect/jsonrpc-utils": "^1.0.6",
-                        "@walletconnect/safe-json": "^1.0.2",
-                        "events": "^3.3.0",
-                        "ws": "^7.5.1"
-                    }
-                },
                 "@walletconnect/sign-client": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.5.tgz",
-                    "integrity": "sha512-5NJ8/BAOlP3runG0++YqWdiNygd0LtHls0LfBa/I+sYpYDMjQaMc18ISqKK9wlIws7rI+UZIGxZphg2N050V7A==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.2.tgz",
+                    "integrity": "sha512-/wigdCIQjlBXSWY43Id0IPvZ5biq4HiiQZti8Ljvx408UYjmqcxcBitbj2UJXMYkid7704JWAB2mw32I1HgshQ==",
                     "requires": {
-                        "@walletconnect/core": "2.17.5",
+                        "@walletconnect/core": "2.17.2",
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/logger": "2.1.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0"
                     }
                 },
                 "@walletconnect/types": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.5.tgz",
-                    "integrity": "sha512-fFddisuI7B58bY8GKA2e1jZ/o+kh7aQDFohERA1Rot6s9lRepG2w4eR0UDVSldS9hdJS9l7MzCAvEZeHksMaRg==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.2.tgz",
+                    "integrity": "sha512-j/+0WuO00lR8ntu7b1+MKe/r59hNwYLFzW0tTmozzhfAlDL+dYwWasDBNq4AH8NbVd7vlPCQWmncH7/6FVtOfQ==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/heartbeat": "1.2.2",
@@ -9378,9 +9193,9 @@
                     }
                 },
                 "@walletconnect/universal-provider": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.5.tgz",
-                    "integrity": "sha512-opxFdJWzOZz6LwKAXk5gxqzPT7kdgNH5fyjQ45Q2cseLr5f9uR1JREAQA2stSNCPY4Yk7bxCxSLN6djzpfykgA==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.17.2.tgz",
+                    "integrity": "sha512-yIWDhBODRa9J349d/i1sObzon0vy4n+7R3MvGQQYaU1EVrV+WfoGSRsu8U7rYsL067/MAUu9t/QrpPblaSbz7g==",
                     "requires": {
                         "@walletconnect/events": "1.0.1",
                         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -9389,17 +9204,17 @@
                         "@walletconnect/jsonrpc-utils": "1.0.8",
                         "@walletconnect/keyvaluestorage": "1.1.1",
                         "@walletconnect/logger": "2.1.2",
-                        "@walletconnect/sign-client": "2.17.5",
-                        "@walletconnect/types": "2.17.5",
-                        "@walletconnect/utils": "2.17.5",
+                        "@walletconnect/sign-client": "2.17.2",
+                        "@walletconnect/types": "2.17.2",
+                        "@walletconnect/utils": "2.17.2",
                         "events": "3.3.0",
                         "lodash": "4.17.21"
                     }
                 },
                 "@walletconnect/utils": {
-                    "version": "2.17.5",
-                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.5.tgz",
-                    "integrity": "sha512-3qBeAuEeYw/xbonhK1wC+j1y5I9Fn5qX3D5jW5SuTd1d4SsRSzgUi7SFCFwU1u4LitkEae16FNmTOk4lrrXY3g==",
+                    "version": "2.17.2",
+                    "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.2.tgz",
+                    "integrity": "sha512-T7eLRiuw96fgwUy2A5NZB5Eu87ukX8RCVoO9lji34RFV4o2IGU9FhTEWyd4QQKI8OuQRjSknhbJs0tU0r0faPw==",
                     "requires": {
                         "@ethersproject/hash": "5.7.0",
                         "@ethersproject/transactions": "5.7.0",
@@ -9414,11 +9229,12 @@
                         "@walletconnect/relay-auth": "1.0.4",
                         "@walletconnect/safe-json": "1.0.2",
                         "@walletconnect/time": "1.0.2",
-                        "@walletconnect/types": "2.17.5",
+                        "@walletconnect/types": "2.17.2",
                         "@walletconnect/window-getters": "1.0.1",
                         "@walletconnect/window-metadata": "1.0.1",
                         "detect-browser": "5.3.0",
-                        "elliptic": "6.6.1",
+                        "elliptic": "6.6.0",
+                        "query-string": "7.1.3",
                         "uint8arrays": "3.1.0"
                     }
                 },
@@ -9428,9 +9244,9 @@
                     "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
                 },
                 "elliptic": {
-                    "version": "6.6.1",
-                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-                    "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
+                    "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
                     "requires": {
                         "bn.js": "^4.11.9",
                         "brorand": "^1.1.0",
@@ -9440,22 +9256,16 @@
                         "minimalistic-assert": "^1.0.1",
                         "minimalistic-crypto-utils": "^1.0.1"
                     }
-                },
-                "ws": {
-                    "version": "7.5.10",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-                    "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-                    "requires": {}
                 }
             }
         },
         "@reown/appkit-wallet": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.6.5.tgz",
-            "integrity": "sha512-3o0+W/JP4rFpPInp4ScNLvr0N++98ErJIjQYjws6fP2KftQAkjUCGeMvYbVXf7sxh3Xu/WkN94SppOZ/WsBWBg==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.6.4.tgz",
+            "integrity": "sha512-GfS4+ESVEGubkLrPEOE/QOSufkzSU7FZRK+RG4mD4zMjx2dcXEMrSBOuNOOf5PdgCFdd3XLCPfPj6HhMyVcVWQ==",
             "requires": {
-                "@reown/appkit-common": "1.6.5",
-                "@reown/appkit-polyfills": "1.6.5",
+                "@reown/appkit-common": "1.6.4",
+                "@reown/appkit-polyfills": "1.6.4",
                 "@walletconnect/logger": "2.1.2",
                 "zod": "3.22.4"
             }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@openzeppelin/merkle-tree": "^1.0.5",
-        "@reown/appkit": "^1.6.5",
-        "@reown/appkit-adapter-wagmi": "^1.6.5",
+        "@reown/appkit": "1.6.4",
+        "@reown/appkit-adapter-wagmi": "1.6.4",
         "@vueuse/sound": "^2.0.1",
         "@wagmi/connectors": "^5.7.5",
         "@wagmi/core": "^2.16.3",

--- a/src/core.js
+++ b/src/core.js
@@ -3,7 +3,7 @@ import { fallback, http, webSocket } from "viem";
 import { polygon } from "@reown/appkit/networks";
 import { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 
-const projectId = "25cdcfa92d5dc817ebb3f05d1cccf17b";
+const projectId = "96d9e23deb01fd797668d4bf3af4fec9";
 const metadata = {
   name: "VERSE Voyagers",
   description:

--- a/src/core.js
+++ b/src/core.js
@@ -29,7 +29,7 @@ const wagmiAdapter = new WagmiAdapter({
   connectors: [
     walletConnect({
       projectId,
-      showQrModal: true,
+      showQrModal: false,
       metadata,
     }),
     ...(isWallet === true


### PR DESCRIPTION
The new reown version is very buggy. Every patch on the version contains breaking change. To fix this, we use strict version by removing the "^" symbol to tell the package manager (npm) to strictly use version 1.6.4.